### PR TITLE
fixed algo issue

### DIFF
--- a/Source/SsdeepNET/BlockhashContext.cs
+++ b/Source/SsdeepNET/BlockhashContext.cs
@@ -25,7 +25,7 @@ namespace SsdeepNET
         public void Hash(byte c)
         {
             H = Hash(c, H);
-            HalfH = Hash(c, H);
+            HalfH = Hash(c, HalfH);
         }
 
         /* A simple non-rolling hash, based on the FNV hash. */


### PR DESCRIPTION
I'm using ssdeep as the base for tests, and most files produce identical hashes. however, for a few i get a final character mismatch. For example:
```
ssdeep: 3072:PuxJiNAcezcDuKZDKCUoqH62EY+AksyudLOBtxHiel42r1L3CzKPbN+yBReqGo:1CGuKZD75f
SsdeepNET: 3072:PuxJiNAcezcDuKZDKCUoqH62EY+AksyudLOBtxHiel42r1L3CzKPbN+yBReqGo:1CGuKZD75H
```
After digging through the ssdeep 2.13 code, the problem seems to stem from line ~251. After making the small change i get:
```
ssdeep: 3072:PuxJiNAcezcDuKZDKCUoqH62EY+AksyudLOBtxHiel42r1L3CzKPbN+yBReqGo:1CGuKZD75f
SsdeepNET: 3072:PuxJiNAcezcDuKZDKCUoqH62EY+AksyudLOBtxHiel42r1L3CzKPbN+yBReqGo:1CGuKZD75f
```